### PR TITLE
feat: blockDevice async num_blocks

### DIFF
--- a/src/blockdevice.rs
+++ b/src/blockdevice.rs
@@ -56,7 +56,7 @@ pub trait BlockDevice {
     ) -> Result<(), Self::Error>;
 
     /// Determine how many blocks this device can hold.
-    fn num_blocks(&self) -> Result<BlockCount, Self::Error>;
+    async fn num_blocks(&self) -> Result<BlockCount, Self::Error>;
 }
 
 impl Block {


### PR DESCRIPTION
When we use an SPI implementation rather than a microcontroller driver ( like https://github.com/embassy-rs/embassy/blob/80d7193b5b7442fb7a9cee00a5a51300778acdcd/embassy-stm32/src/sdmmc/mod.rs#L1563-L1567) we need to make sure that the card is initialized and to read the `card specific data` block. Since the SPI impl is async we cannot do this without the `num_blocks` being async as well.